### PR TITLE
Bug 1296573 - fix form urls in jinja templates

### DIFF
--- a/atmo/templates/atmo/delete-cluster.jinja
+++ b/atmo/templates/atmo/delete-cluster.jinja
@@ -1,4 +1,4 @@
-<form action="/delete-cluster/" method="POST" enctype="multipart/form-data" id="delete-cluster-form" style="display: inline-block">
+<form action="{{ url('clusters-delete') }}" method="POST" enctype="multipart/form-data" id="delete-cluster-form" style="display: inline-block">
   {% csrf_token %}
   {{ delete_cluster_form.cluster }}
   <button type="submit" class="btn btn-md btn-danger" title="Delete selected Spark cluster">

--- a/atmo/templates/atmo/edit-cluster.jinja
+++ b/atmo/templates/atmo/edit-cluster.jinja
@@ -3,7 +3,7 @@
 </button>
 <div class="modal fade" id="edit-cluster-dialog" tabindex="-1" role="dialog" aria-labelledby="edit-cluster-dialog">
   <div class="modal-dialog" role="document">
-    <form class="modal-content" action="/edit-cluster/" method="POST" enctype="multipart/form-data">
+    <form class="modal-content" action="{{ url('clusters-edit') }}" method="POST" enctype="multipart/form-data">
       {% csrf_token %}
       {{ edit_cluster_form.cluster }}
       <div class="modal-header">

--- a/atmo/templates/atmo/new-cluster.jinja
+++ b/atmo/templates/atmo/new-cluster.jinja
@@ -3,7 +3,7 @@
 </button>
 <div class="modal fade" id="new-cluster-dialog" tabindex="-1" role="dialog" aria-labelledby="new-cluster-dialog">
   <div class="modal-dialog" role="document">
-    <form class="modal-content" action="/new-cluster/" method="POST" enctype="multipart/form-data">
+    <form class="modal-content" action="{{ url('clusters-new') }}" method="POST" enctype="multipart/form-data">
       {% csrf_token %}
       <div class="modal-header">
         <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>

--- a/atmo/templates/atmo/new-worker.jinja
+++ b/atmo/templates/atmo/new-worker.jinja
@@ -3,7 +3,7 @@
 </button>
 <div class="modal fade" id="new-worker-dialog" tabindex="-1" role="dialog" aria-labelledby="new-worker-dialog">
   <div class="modal-dialog" role="document">
-    <form class="modal-content" action="/new-worker/" method="POST" enctype="multipart/form-data">
+    <form class="modal-content" action="{{ url('workers-new') }}" method="POST" enctype="multipart/form-data">
       {% csrf_token %}
       <div class="modal-header">
         <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>

--- a/atmo/workers/urls.py
+++ b/atmo/workers/urls.py
@@ -2,5 +2,5 @@ from django.conf.urls import url
 from . import views
 
 urlpatterns = [
-    url(r'^new/$', views.new_worker),
+    url(r'^new/$', views.new_worker, name='workers-new'),
 ]


### PR DESCRIPTION
Some of the forms were using outdated static urls.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/telemetry-analysis-service/10)
<!-- Reviewable:end -->
