### PR TITLE
Set "VisibleToAllUsers" to True in cluster_start

### DIFF
--- a/atmo/utils/provisioning.py
+++ b/atmo/utils/provisioning.py
@@ -51,7 +51,8 @@ def cluster_start(user_email, identifier, size, public_key):
             {'Key': 'Owner', 'Value': user_email},
             {'Key': 'Name', 'Value': identifier},
             {'Key': 'Application', 'Value': settings.AWS_CONFIG['INSTANCE_APP_TAG']},
-        ]
+        ],
+        VisibleToAllUsers=True
     )
 
     return cluster['JobFlowId']


### PR DESCRIPTION
When this flag is not set to True and using IAM roles, the clusters (as far as I can tell) become orphaned and are not visible or able to be terminated by anyone except the AWS account holder.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/telemetry-analysis-service/11)
<!-- Reviewable:end -->
