### PR TITLE
Bug 1303104 - Use forked version of rq-scheduler

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,5 +29,8 @@ rq_scheduler:
   links:
     - db
     - redis
+    # django-rq doesn't support rqscheduler `retry` mode yet
+    # so we need to use the original startup script, which retrieves
+    # the
   command:
-    python manage.py rqscheduler
+    rqscheduler --url=redis://redis:6379

--- a/requirements.txt
+++ b/requirements.txt
@@ -91,5 +91,5 @@ django-rq==0.9.2 \
     --hash=sha256:96866bc0a3bde4cb5fa0ea8d70249a5b01bcdcb30cce5e2ff8b493feffd3abfa
 croniter==0.3.12 \
     --hash=sha256:445cb26bc2f3cff25a7b06575caf98312b552affffeee0437f26d416c6e3c895
-rq-scheduler==0.7.0 \
-    --hash=sha256:ae609515d408ebd33e7869fa0abe97ddb203b6ada0d6591531dbc9c4f0f8ac3c
+https://github.com/maurodoglio/rq-scheduler/archive/lock-retry.zip#rq-scheduler \
+    --hash=sha256:23d389e8e7139a5f7c63972a4e3a5314436137d109fd6d2117455e862747af95


### PR DESCRIPTION
My fork of rq-scheduler supports running multiple schedulers
side-by-side. Once my patch gets merged we can point the requirements
back to the upstream version.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/telemetry-analysis-service/17)
<!-- Reviewable:end -->
