### PR TITLE
Bug 1307087 - Fix SparkJob.should_run when a job has no expiration

### DIFF
--- a/atmo/jobs/models.py
+++ b/atmo/jobs/models.py
@@ -1,7 +1,8 @@
 from datetime import datetime, timedelta
-from pytz import UTC
+
 from django.db import models
 from django.contrib.auth.models import User
+from django.utils import timezone
 
 from ..utils import provisioning, scheduling
 
@@ -75,7 +76,7 @@ class SparkJob(models.Model):
         if self.current_run_jobflow_id is None:
             return False  # job isn't even running at the moment
         if at_time is None:
-            at_time = datetime.now().replace(tzinfo=UTC)
+            at_time = timezone.now()
         if self.last_run_date + timedelta(hours=self.job_timeout) >= at_time:
             return True  # current job run expired
         return False
@@ -85,7 +86,7 @@ class SparkJob(models.Model):
         if self.current_run_jobflow_id is not None:
             return False  # the job is still running, don't start it again
         if at_time is None:
-            at_time = datetime.now().replace(tzinfo=UTC)
+            at_time = timezone.now()
         active = self.start_date <= at_time <= self.end_date
         hours_since_last_run = (
             float("inf")  # job was never run before

--- a/atmo/jobs/models.py
+++ b/atmo/jobs/models.py
@@ -72,7 +72,7 @@ class SparkJob(models.Model):
             self.most_recent_status = info["state"]
         return self.most_recent_status
 
-    def is_expired(self, at_time = None):
+    def is_expired(self, at_time=None):
         if self.current_run_jobflow_id is None:
             return False  # job isn't even running at the moment
         if at_time is None:
@@ -81,13 +81,15 @@ class SparkJob(models.Model):
             return True  # current job run expired
         return False
 
-    def should_run(self, at_time = None):
+    def should_run(self, at_time=None):
         """Return True if the scheduled Spark job should run, False otherwise."""
         if self.current_run_jobflow_id is not None:
             return False  # the job is still running, don't start it again
         if at_time is None:
             at_time = timezone.now()
-        active = self.start_date <= at_time <= self.end_date
+        active = self.start_date <= at_time
+        if self.end_date is not None:
+            active = active and self.end_date >= at_time
         hours_since_last_run = (
             float("inf")  # job was never run before
             if self.last_run_date is None else

--- a/atmo/workers/models.py
+++ b/atmo/workers/models.py
@@ -1,8 +1,8 @@
-from datetime import datetime, timedelta
-from pytz import UTC
+from datetime import timedelta
 
 from django.db import models
 from django.contrib.auth.models import User
+from django.utils import timezone
 
 from ..utils import provisioning
 
@@ -53,7 +53,7 @@ class Worker(models.Model):
 
         # set the dates
         if not self.start_date:
-            self.start_date = datetime.now().replace(tzinfo=UTC)
+            self.start_date = timezone.now()
         if not self.end_date:
             self.end_date = self.start_date + timedelta(days=1)  # workers expire after 1 day
         return super(Worker, self).save(*args, **kwargs)


### PR DESCRIPTION
Also added a bunch of tests for the logic in `should_run`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/telemetry-analysis-service/22)
<!-- Reviewable:end -->
