### PR TITLE
Bug 1311457 - Show termination time in cluster detail page instead of timedelta

### DIFF
--- a/atmo/static/js/base.js
+++ b/atmo/static/js/base.js
@@ -1,0 +1,5 @@
+$(function() {
+  $(document).ready( function() {
+    $('[data-toggle="tooltip"]').tooltip();
+  });
+});

--- a/atmo/static/js/refresher.js
+++ b/atmo/static/js/refresher.js
@@ -5,8 +5,17 @@ $(function() {
           refresh_container = '#refresh-container',
           refresh_timer = '#refresh-timer',
           refresher = $('#refresher'),
+          time = $('#time'),
           timeout = 60,
           timeout_id;
+      var utc_now = function() {
+        return moment().utcOffset(0).format('YYYY-MM-DD HH:mm:ss');
+      }
+      var updateTime = function() {
+        time.attr('data-original-title', utc_now());
+        window.setTimeout(updateTime, 1000);
+      }
+      updateTime();
 
       // if a refresher URL was found
       if (jQuery.type(refresh_url) !== "undefined") {

--- a/atmo/templates/atmo/base.html
+++ b/atmo/templates/atmo/base.html
@@ -77,7 +77,7 @@
             <li><a href="https://bugzilla.mozilla.org/enter_bug.cgi?product=Cloud%20Services&component=Metrics%3A%20Pipeline&short_desc=ATMO%20V2%3A%20" target="_blank">Report a bug</a></li>
             <li><a href="https://github.com/mozilla/telemetry-analysis-service" target="_blank">Contribute code</a></li>
           </ul>
-          <p class="navbar-text navbar-right">All times in UTC</p>
+          <p class="navbar-text navbar-right" data-toggle="tooltip" id="time">All times in UTC</p>
           <p class="navbar-text navbar-right hidden" id="refresher">
             Refresh<span id="refresh-timer"></span>
           </p>
@@ -85,6 +85,7 @@
       </div>
     </nav>
   </body>
+  <script type="text/javascript" src="{% static "js/base.js" %}"></script>
   <script type="text/javascript" src="{% static "js/forms.js" %}"></script>
   <script type="text/javascript" src="{% static "js/refresher.js" %}"></script>
 </html>

--- a/atmo/templates/atmo/cluster-detail.html
+++ b/atmo/templates/atmo/cluster-detail.html
@@ -11,9 +11,11 @@
 <div class="row">
   <div class="col-sm-9">
   {% if cluster.is_active %}
-    <p class="lead">
-      This cluster will be automatically terminated in
-      <strong>{{ cluster.end_date|timeuntil }}</strong>.
+    <p class="alert alert-info">
+      This cluster will be automatically terminated at
+      <strong
+        data-toggle="tooltip"
+        title="In {{ cluster.end_date|timeuntil }}">{{ cluster.end_date }} UTC</strong>.
       Be sure to save any work!
     </p>
     <h3>Access</h3>


### PR DESCRIPTION
This also shows a tooltip for the timedelta and the current UTC time as a tooltip over the time in the footer
