### PR TITLE
Factor confirmation form into own mixin

### DIFF
--- a/atmo/clusters/forms.py
+++ b/atmo/clusters/forms.py
@@ -5,11 +5,13 @@ from django import forms
 from django.conf import settings
 
 from . import models
-from ..forms.mixins import CreatedByFormMixin, FormControlFormMixin
+from ..forms.mixins import (ConfirmationModelFormMixin, CreatedByModelFormMixin,
+                            FormControlFormMixin)
 from ..forms.fields import PublicKeyFileField
 
 
-class NewClusterForm(FormControlFormMixin, CreatedByFormMixin, forms.ModelForm):
+class NewClusterForm(FormControlFormMixin, CreatedByModelFormMixin,
+                     forms.ModelForm):
     prefix = 'new'
 
     identifier = forms.RegexField(
@@ -50,25 +52,12 @@ class NewClusterForm(FormControlFormMixin, CreatedByFormMixin, forms.ModelForm):
         fields = ['identifier', 'size', 'public_key', 'emr_release']
 
 
-class TerminateClusterForm(FormControlFormMixin, CreatedByFormMixin, forms.ModelForm):
+class TerminateClusterForm(ConfirmationModelFormMixin, CreatedByModelFormMixin,
+                           FormControlFormMixin, forms.ModelForm):
     prefix = 'terminate'
-
-    confirmation = forms.RegexField(
-        required=True,
-        label='Confirm termination with cluster identifier',
-        regex=r'^[\w-]{1,100}$',
-        widget=forms.TextInput(attrs={
-            'required': 'required',
-        }),
-    )
-
-    def clean_confirmation(self):
-        confirmation = self.cleaned_data.get('confirmation')
-        if confirmation != self.instance.identifier:
-            raise forms.ValidationError(
-                "Entered cluster identifier doesn't match"
-            )
-        return confirmation
+    confirmation_error = "Entered cluster identifier doesn't match"
+    confirmation_field = 'identifier'
+    confirmation_label = 'Confirm termination with cluster identifier'
 
     class Meta:
         model = models.Cluster

--- a/atmo/forms/fields.py
+++ b/atmo/forms/fields.py
@@ -30,7 +30,7 @@ class PublicKeyFileField(forms.FileField):
 
 class CachedFileField(forms.FileField):
     """
-    A custom FileField class for use in conjunction with CachedFileFormMixin
+    A custom FileField class for use in conjunction with CachedFileModelFormMixin
     that allows storing uploaded file in a cache for re-submission.
 
     That requires moving the "required" validation into the form's clean


### PR DESCRIPTION
This also uses django.forms.models.ModelForm as the
base class of the mixin to have a consistent bases for
our forms.
