### PR TITLE
Bug 1319545 - Add CSP report URI to settings

### DIFF
--- a/atmo/settings.py
+++ b/atmo/settings.py
@@ -103,6 +103,9 @@ class CSP(object):
         'http://*.mozilla.net',
         'https://*.mozilla.net',
     )
+    CSP_REPORT_URI = (
+        "/__cspreport__"
+    )
 
 
 class Core(CSP, AWS, Configuration):


### PR DESCRIPTION
Add a CSP report endpoint that will be handled in nginx.

In dev, this will send to an endpoint that 404s so it could be moved in to stage/prod specific config.