### PR TITLE
Fix CircleCi builds

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -18,6 +18,7 @@ machine:
 
 dependencies:
   pre:
+    - sudo apt-get update
     - sudo apt-get install python-dev
     - sudo pip install -U docker-compose
 


### PR DESCRIPTION
The CircleCi build is failing because is missing a apt-get update