### PR TITLE
Bug #1332432 - use the correct bugzilla bug prefix

### DIFF
--- a/.pyup.yml
+++ b/.pyup.yml
@@ -1,5 +1,5 @@
 search: False
 label_prs: update
-pr_prefix: "Bug #1332432"
+pr_prefix: "Bug #1332432 -"
 requirements:
   - requirements.txt


### PR DESCRIPTION
I've refactored the code on pyup.io's side a little: it now allows to set arbitrary prefixes without special separation characters.

Adding ` -` to the prefix should make @autoloader happy.

cc @jezdez