### PR TITLE
Add email arg to bootstrap file

### DIFF
--- a/atmo/provisioning.py
+++ b/atmo/provisioning.py
@@ -76,7 +76,7 @@ def cluster_start(user_email, identifier, size, public_key, emr_release):
                 'Path': 's3://{}/bootstrap/telemetry.sh'.format(
                     settings.AWS_CONFIG['SPARK_EMR_BUCKET']
                 ),
-                'Args': ['--public-key', public_key]
+                'Args': ['--public-key', public_key, '--email', user_email]
             }
         }],
         Tags=[

--- a/atmo/scheduling.py
+++ b/atmo/scheduling.py
@@ -91,7 +91,7 @@ def spark_job_run(user_email, identifier, notebook_uri, result_is_public, size,
                 'Path': 's3://{}/bootstrap/telemetry.sh'.format(
                     settings.AWS_CONFIG['SPARK_EMR_BUCKET']
                 ),
-                'Args': ['--timeout', str(job_timeout * 60)]
+                'Args': ['--timeout', str(job_timeout * 60), '--email', user_email]
             }
         }],
         Tags=[


### PR DESCRIPTION
This will be used to support mounting EFS on EMR machines, so each user can have their own directory mounted.

For the mount to work, [0] needs to be merged. It still works on the current bootstrap script, and is just ignored.

[0] PR for mounting EFS: https://github.com/mozilla/emr-bootstrap-spark/pull/57

