### PR TITLE
Close database connections on startup of the worker, before and after each job.

### DIFF
--- a/atmo/worker.py
+++ b/atmo/worker.py
@@ -1,0 +1,26 @@
+from django.db import connections, DatabaseError, InterfaceError
+from rq_retry import RetryWorker
+
+
+class ConnectionClosingRetryWorker(RetryWorker):
+    def close_database(self):
+        for connection in connections.all():
+            try:
+                connection.close()
+            except InterfaceError:
+                pass
+            except DatabaseError as exc:
+                str_exc = str(exc)
+                if 'closed' not in str_exc and 'not connected' not in str_exc:
+                    raise
+
+    def perform_job(self, *args, **kwargs):
+        self.close_database()
+        try:
+            return super().perform_job(*args, **kwargs)
+        finally:
+            self.close_database()
+
+    def work(self, *args, **kwargs):
+        self.close_database()
+        return super().work(*args, **kwargs)

--- a/bin/run
+++ b/bin/run
@@ -40,7 +40,7 @@ case $1 in
     exec python manage.py runserver 0.0.0.0:${PORT}
     ;;
   worker)
-    exec newrelic-admin run-python manage.py rqworker --worker-class=rq_retry.RetryWorker default
+    exec newrelic-admin run-python manage.py rqworker --worker-class=atmo.worker.ConnectionClosingRetryWorker default
     ;;
   scheduler)
     exec newrelic-admin run-python manage.py rqscheduler


### PR DESCRIPTION
Fix #245.