### PR TITLE
Fix #207: Reverse log display order

### DIFF
--- a/atmo/templates/atmo/jobs/detail.html
+++ b/atmo/templates/atmo/jobs/detail.html
@@ -105,7 +105,7 @@
             </p>
           </div>
           <ul class="list-group">
-          {% for item in results.logs %}
+          {% for item in results.logs reversed %}
           <li class="list-group-item">
             {% if spark_job.is_public %}
               <a href="{{ settings.PUBLIC_DATA_URL }}{{ item }}">


### PR DESCRIPTION
AWS returns these in lexicographical order. These are named following a
pattern of <identifier>/logs/<identifier>.<YYYYMMDDHHMMSS>.log.gz so by
default they would be ordered by date.