### PR TITLE
correct logic on existance of .env file

### DIFF
--- a/bin/test
+++ b/bin/test
@@ -2,7 +2,7 @@
 set -eo pipefail
 
 # copy the .env template to .env if not there already
-[ ! -f .env ] && cp .env-dist .env
+[ ! -f .env ] || cp .env-dist .env
 
 # default variables
 export DEVELOPMENT=1


### PR DESCRIPTION
If the file does *not* exist, *then* it should copy from the dist version. Right?