### PR TITLE
Use django_celery_monitor to be able to inspect Celery tasks and workers in realtime.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,5 +18,6 @@ node_modules/
 .bash_history
 coverage
 celerybeat.pid
+celerymonitor.pid
 .psql_history
 .python_history

--- a/atmo/settings.py
+++ b/atmo/settings.py
@@ -250,6 +250,7 @@ class Core(AWS, Celery, Constance, CSP, Configuration):
         'constance',
         'constance.backends.database',
         'dockerflow.django',
+        'django_celery_monitor',
         'django_celery_results',
 
         # Django apps

--- a/bin/run
+++ b/bin/run
@@ -5,6 +5,7 @@ set -eo pipefail
 : "${PORT:=8000}"
 : "${SLEEP:=1}"
 : "${TRIES:=60}"
+: "${MONITOR_PIDFILE:=/app/celerymonitor.pid}"
 
 usage() {
   echo "usage: bin/run web|web-dev|worker|scheduler|test"
@@ -45,6 +46,12 @@ case $1 in
   scheduler)
     python manage.py migrate --noinput
     exec newrelic-admin run-program celery -A atmo.celery:celery beat -l info --pidfile /app/celerybeat.pid
+    ;;
+  monitor)
+    [ -f ${MONITOR_PIDFILE} ] && rm ${MONITOR_PIDFILE}
+    exec newrelic-admin run-program celery -A atmo.celery:celery \
+      events -l info -c django_celery_monitor.camera.Camera --frequency=2.0 \
+      --pidfile ${MONITOR_PIDFILE}
     ;;
   test)
     coverage erase

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,3 +51,13 @@ services:
       - db
       - redis
     command: scheduler
+
+  monitor:
+    extends:
+      service: app
+    depends_on:
+      - app
+    links:
+      - db
+      - redis
+    command: monitor

--- a/requirements.txt
+++ b/requirements.txt
@@ -381,3 +381,6 @@ django-mail-builder==0.3 \
     --hash=sha256:35948e8d7025b23e520a67767935547efae100da9757723100fa0a220f23ef2f
 django-amazon-ses==0.3.0 \
     --hash=sha256:a270a4776fc1826e2e31b9507ec822d6adc5a6f2b5d12d3a85deec2d6cb98e12
+django_celery_monitor==1.0.1 \
+    --hash=sha256:b3f9a5e1b5cf751ac750153038f5b4f7ad60a652f36e8b49c31e59ce55c0a138 \
+    --hash=sha256:95ea0a3bc55af27e929f5eb745bc459f3e9c1afb149b9e83100f4fbd514425f2


### PR DESCRIPTION
For the record, [django_celery_monitor](https://pypi.python.org/pypi/django_celery_monitor) is a port of the monitoring feature in the old django-celery app and I released it on PyPI: https://pypi.python.org/pypi/django_celery_monitor