### PR TITLE
Fix #407 - Make sure we always run in dev mode so we wait for database and redis.

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -4,6 +4,7 @@ MAINTAINER Jannis Leidel <jezdez@mozilla.com>
 ENV PYTHONUNBUFFERED=1 \
     PYTHONPATH=/app/ \
     DJANGO_CONFIGURATION=Dev \
+    DEVELOPMENT=1 \
     PORT=8000
 
 EXPOSE $PORT

--- a/bin/test
+++ b/bin/test
@@ -5,7 +5,6 @@ set -eo pipefail
 [ ! -f .env ] && cp .env-dist .env
 
 # default variables
-export DEVELOPMENT=1
 export DJANGO_CONFIGURATION=Test
 
 # pass CI env vars into docker containers for codecov submission
@@ -14,4 +13,4 @@ export DJANGO_CONFIGURATION=Test
     export CI_ENV=`bash <(curl -s https://codecov.io/env)`
 
 # run docker compose with the given environment variables
-docker-compose run -e DEVELOPMENT -e DJANGO_CONFIGURATION $CI_ENV web test
+docker-compose run -e DJANGO_CONFIGURATION $CI_ENV web test


### PR DESCRIPTION
This basically makes sure the `wait_for` function in the `bin/run` is properly used in development. We already set the `DEVELOPMENT` env var when running tests via `bin/test` but it seems as if this was mistakenly missed in setting it for when we just start the server via `make up` etc. Since we're using an own Dockerfile for development (`Dockerfile.dev`) we can easily set it there and don't have to think about it much.