### PR TITLE
Make sure the scheduler will only ever run run as a singleton.

### DIFF
--- a/atmo/celery.py
+++ b/atmo/celery.py
@@ -8,8 +8,6 @@ from celery import Celery
 from celery.five import string_t
 from celery.task import current
 from celery.utils.time import maybe_iso8601
-from redbeat.schedulers import add_defaults
-from redis.client import StrictRedis
 
 
 # set the default Django settings module for the 'celery' program.
@@ -95,12 +93,6 @@ celery = AtmoCelery('atmo')
 # - namespace='CELERY' means all celery-related configuration keys
 #   should have a `CELERY_` prefix.
 celery.config_from_object('django.conf:settings', namespace='CELERY')
-
-# Add RedBeat defaults
-add_defaults(celery)
-
-celery.redbeat_redis = StrictRedis.from_url(celery.conf.REDBEAT_REDIS_URL,
-                                            decode_responses=True)
 
 # Load task modules from all registered Django celery configs.
 celery.autodiscover_tasks()

--- a/atmo/settings.py
+++ b/atmo/settings.py
@@ -55,9 +55,9 @@ class Celery:
     # Maximum time to sleep between re-checking the schedule
     CELERY_BEAT_MAX_LOOP_INTERVAL = 5  # redbeat likes fast loops
     # Unless refreshed the lock will expire after this time
-    REDBEAT_LOCK_TIMEOUT = CELERY_BEAT_MAX_LOOP_INTERVAL * 5
+    CELERY_REDBEAT_LOCK_TIMEOUT = CELERY_BEAT_MAX_LOOP_INTERVAL * 5
     # The default/initial schedule to use.
-    CELERYBEAT_SCHEDULE = CELERY_BEAT_SCHEDULE = {
+    CELERY_BEAT_SCHEDULE = {
         'expire_jobs': {
             'schedule': crontab(minute='*'),
             'task': 'atmo.jobs.tasks.expire_jobs',
@@ -448,7 +448,7 @@ class Base(Core):
         environ_name='REDIS_URL',
     )
     # Use redis as the Celery broker.
-    REDBEAT_REDIS_URL = CELERY_BROKER_URL = os.environ.get('REDIS_URL', REDIS_URL_DEFAULT)
+    CELERY_BROKER_URL = os.environ.get('REDIS_URL', REDIS_URL_DEFAULT)
 
     LOGGING_USE_JSON = values.BooleanValue(False)
 

--- a/bin/run
+++ b/bin/run
@@ -45,7 +45,8 @@ case $1 in
     ;;
   scheduler)
     python manage.py migrate --noinput
-    exec newrelic-admin run-program celery -A atmo.celery:celery beat -l info --pidfile /app/celerybeat.pid
+    exec newrelic-admin run-program celery -A atmo.celery:celery \
+      beat -l info --pidfile /tmp/celerybeat.pid
     ;;
   monitor)
     [ -f ${MONITOR_PIDFILE} ] && rm ${MONITOR_PIDFILE}

--- a/requirements.txt
+++ b/requirements.txt
@@ -354,8 +354,8 @@ vine==1.1.3 \
 django_celery_results==1.0.1 \
     --hash=sha256:dfa240fb535a1a2d01c9e605ad71629909318eae6b893c5009eafd7265fde10b \
     --hash=sha256:8bca2605eeff4418be7ce428a6958d64bee0f5bdf1f8e563fbc09a9e2f3d990f
-https://github.com/sibson/redbeat/archive/5e62e1eb6aa451cd5f3d6ce0d490f71b48615b13.zip \
-    --hash=sha256:e8676b34fe0f131a8516c7f9ce9128490381f449e4ddc77bf33dd7e96a51acd5
+celery-redbeat==0.10.0 \
+    --hash=sha256:0ac7e6fbf09b91e03a4b2f92474a82bacf256f0f82e0c29f147358a91b26c472
 furl==1.0.0 \
     --hash=sha256:874dae78a19ec08dcdca83f007824c090501fa95e55e965a64fcff8b8c5e7230
 orderedmultidict==0.7.11 \

--- a/requirements.txt
+++ b/requirements.txt
@@ -354,8 +354,8 @@ vine==1.1.3 \
 django_celery_results==1.0.1 \
     --hash=sha256:dfa240fb535a1a2d01c9e605ad71629909318eae6b893c5009eafd7265fde10b \
     --hash=sha256:8bca2605eeff4418be7ce428a6958d64bee0f5bdf1f8e563fbc09a9e2f3d990f
-https://github.com/jezdez/redbeat/archive/lock-settings.zip \
-    --hash=sha256:a08ed9b9fec47b115a424996109dd4febab84e25ebe1292a17f85f21e81e4489
+https://github.com/sibson/redbeat/archive/5e62e1eb6aa451cd5f3d6ce0d490f71b48615b13.zip \
+    --hash=sha256:e8676b34fe0f131a8516c7f9ce9128490381f449e4ddc77bf33dd7e96a51acd5
 furl==1.0.0 \
     --hash=sha256:874dae78a19ec08dcdca83f007824c090501fa95e55e965a64fcff8b8c5e7230
 orderedmultidict==0.7.11 \

--- a/requirements.txt
+++ b/requirements.txt
@@ -354,8 +354,8 @@ vine==1.1.3 \
 django_celery_results==1.0.1 \
     --hash=sha256:dfa240fb535a1a2d01c9e605ad71629909318eae6b893c5009eafd7265fde10b \
     --hash=sha256:8bca2605eeff4418be7ce428a6958d64bee0f5bdf1f8e563fbc09a9e2f3d990f
-celery-redbeat==0.10.0rc1 \
-    --hash=sha256:8c84687742379d795d4ab00a75fc4bfe73f77546aeb7fc183c33ce94b0fa4173
+https://github.com/jezdez/redbeat/archive/lock-settings.zip \
+    --hash=sha256:a08ed9b9fec47b115a424996109dd4febab84e25ebe1292a17f85f21e81e4489
 furl==1.0.0 \
     --hash=sha256:874dae78a19ec08dcdca83f007824c090501fa95e55e965a64fcff8b8c5e7230
 orderedmultidict==0.7.11 \


### PR DESCRIPTION
This uses a fix for redbeat’s distributed Redis lock.
Removing some of the custom setting fixes we had to do as well.

Fix #417.