### PR TITLE
Fix #420 - Add ability to render announcements.

### DIFF
--- a/atmo/templates/atmo/_announcements.html
+++ b/atmo/templates/atmo/_announcements.html
@@ -1,0 +1,11 @@
+{% load atmo %}
+{% if config.ANNOUNCEMENT_ENABLED %}
+<div class="alert alert-{{ config.ANNOUNCMENT_STYLE }} alert-dragons" role="alert">
+  <h4>{{ config.ANNOUNCEMENT_TITLE }}</h4>
+  {% if config.ANNOUNCEMENT_CONTENT_MARKDOWN %}
+    {{ config.ANNOUNCEMENT_CONTENT|markdown|safe }}
+  {% else %}
+    {{ config.ANNOUNCEMENT_CONTENT }}
+  {% endif %}
+</div>
+{% endif %}

--- a/atmo/templates/atmo/base.html
+++ b/atmo/templates/atmo/base.html
@@ -50,6 +50,7 @@
             {% block modified_date_description %}This page contains elements that have been updated on the server.{% endblock modified_date_description %}
             <b><a href="{{ request.build_absolute_uri }}">Please refresh</a></b> this page to see the latest version.
           </div>
+          {% include "atmo/_announcements.html" %}
           {% for message in messages %}
           <div class="alert alert-{{ message.tags }} alert-dismissible alert-dragons" role="alert">
             <button type="button" class="close" data-dismiss="alert" aria-label="Close">

--- a/atmo/templatetags.py
+++ b/atmo/templatetags.py
@@ -6,6 +6,7 @@ from urllib.parse import urljoin
 from django import template
 from django.conf import settings
 
+import CommonMark
 from furl import furl
 
 
@@ -25,3 +26,8 @@ def url_update(url, **kwargs):
 @register.filter
 def full_url(url):
     return urljoin(settings.SITE_URL, url)
+
+
+@register.filter
+def markdown(content):
+    return CommonMark.commonmark(content)


### PR DESCRIPTION
This uses the existing Constance config app in the admin to render optionally a Markdown announcement.

This also adds admin fieldsets to the Constance config page.