### PR TITLE
Fix #550: Filter out inactive EMR releases

### DIFF
--- a/atmo/clusters/forms.py
+++ b/atmo/clusters/forms.py
@@ -14,7 +14,7 @@ class EMRReleaseChoiceField(forms.ModelChoiceField):
     def __init__(self, *args, **kwargs):
         super().__init__(
             label='EMR release',
-            queryset=models.EMRRelease.objects.all(),
+            queryset=models.EMRRelease.objects.active(),
             required=True,
             empty_label=None,
             widget=forms.RadioSelect(attrs={

--- a/atmo/clusters/forms.py
+++ b/atmo/clusters/forms.py
@@ -4,6 +4,7 @@
 from django import forms
 from django.conf import settings
 from django.core.urlresolvers import reverse
+from django.utils.safestring import mark_safe
 
 from . import models
 from ..forms.mixins import AutoClassFormMixin, CreatedByModelFormMixin
@@ -28,11 +29,11 @@ class EMRReleaseChoiceField(forms.ModelChoiceField):
         label = obj.version
         extra = []
         if obj.is_experimental:
-            extra.append('experimental')
+            extra.append('<span class="label label-info">experimental</span>')
         elif obj.is_deprecated:
-            extra.append('deprecated')
+            extra.append('<span class="label label-warning">deprecated</span>')
         if extra:
-            label = '%s (%s)' % (label, ', '.join(extra))
+            label = mark_safe('%s %s' % (label, ''.join(extra)))
         return label
 
 

--- a/atmo/clusters/queries.py
+++ b/atmo/clusters/queries.py
@@ -6,6 +6,11 @@ from django.db import models
 
 class EMRReleaseQuerySet(models.QuerySet):
 
+    def active(self):
+        return self.filter(
+            is_active=True,
+        )
+
     def stable(self):
         return self.filter(
             is_experimental=False,

--- a/tests/clusters/test_forms.py
+++ b/tests/clusters/test_forms.py
@@ -6,11 +6,13 @@ from atmo.clusters.forms import EMRReleaseChoiceField
 
 def test_emr_release_choice_field(emr_release_factory):
     regular = emr_release_factory()
+    inactive = emr_release_factory(is_active=False)
     deprecated = emr_release_factory(is_deprecated=True)
     experimental = emr_release_factory(is_experimental=True)
 
     choice_field = EMRReleaseChoiceField()
     result = choice_field.widget.render('test', regular.pk)
+    assert inactive.version not in result
     assert '%s</label>' % regular.version in result
     assert '%s (experimental)</label>' % experimental.version in result
     assert '%s (deprecated)</label>' % deprecated.version in result

--- a/tests/clusters/test_forms.py
+++ b/tests/clusters/test_forms.py
@@ -5,6 +5,10 @@ from atmo.clusters.forms import EMRReleaseChoiceField
 
 
 def test_emr_release_choice_field(emr_release_factory):
+
+    def make_label(label, text):
+        return '<span class="label label-%s">%s</span>' % (label, text)
+
     regular = emr_release_factory()
     inactive = emr_release_factory(is_active=False)
     deprecated = emr_release_factory(is_deprecated=True)
@@ -14,5 +18,9 @@ def test_emr_release_choice_field(emr_release_factory):
     result = choice_field.widget.render('test', regular.pk)
     assert inactive.version not in result
     assert '%s</label>' % regular.version in result
-    assert '%s (experimental)</label>' % experimental.version in result
-    assert '%s (deprecated)</label>' % deprecated.version in result
+    assert ('%s %s</label>' % (deprecated.version,
+                               make_label('warning', 'deprecated'))
+            in result)
+    assert ('%s %s</label>' % (experimental.version,
+                               make_label('info', 'experimental'))
+            in result)


### PR DESCRIPTION
This also changes the labels from using simple text and parens to using bootstrap labels for deprecated and experimental EMR releases.

Example:
![screenshot 2017-06-15 14 55 54](https://user-images.githubusercontent.com/1106/27203455-c2b3a920-51da-11e7-8415-b7530e6a843e.png)
