### PR TITLE
added description of spark job to failed run alert email

### DIFF
--- a/atmo/templates/atmo/jobs/mails/failed_run_alert.mail
+++ b/atmo/templates/atmo/jobs/mails/failed_run_alert.mail
@@ -7,8 +7,10 @@
 {% block cc %}{{ settings.DEFAULT_FROM_EMAIL }}{% endblock cc %}
 
 {% block body %}
-Your scheduled Spark job "{{ alert.run.spark_job.identifier }}: {{ alert.run.spark_job.description }}" has failed
+Your scheduled Spark job "{{ alert.run.spark_job.identifier }}" has failed
 at approximately {{ alert.run.created_at }} UTC.
+Description: {{ alert.run.spark_job.description }}
+
 
 You may want to check the logs to see what failed in the Spark job.
 

--- a/atmo/templates/atmo/jobs/mails/failed_run_alert.mail
+++ b/atmo/templates/atmo/jobs/mails/failed_run_alert.mail
@@ -7,7 +7,7 @@
 {% block cc %}{{ settings.DEFAULT_FROM_EMAIL }}{% endblock cc %}
 
 {% block body %}
-Your scheduled Spark job "{{ alert.run.spark_job.identifier }}" has failed
+Your scheduled Spark job "{{ alert.run.spark_job.identifier }}: {{ alert.run.spark_job.description }}" has failed
 at approximately {{ alert.run.created_at }} UTC.
 
 You may want to check the logs to see what failed in the Spark job.

--- a/atmo/templates/atmo/jobs/mails/failed_run_alert.mail
+++ b/atmo/templates/atmo/jobs/mails/failed_run_alert.mail
@@ -9,8 +9,8 @@
 {% block body %}
 Your scheduled Spark job "{{ alert.run.spark_job.identifier }}" has failed
 at approximately {{ alert.run.created_at }} UTC.
-Description: {{ alert.run.spark_job.description }}
 
+Description: {{ alert.run.spark_job.description }}
 
 You may want to check the logs to see what failed in the Spark job.
 


### PR DESCRIPTION
Not sure if I should add the description to the title of the mail as well; I think having it in the body is good enough.