### PR TITLE
Remove unnecessary "depends_on" directives in docker compose config

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,8 +25,6 @@ services:
       service: app
     ports:
       - "8000:8000"
-    depends_on:
-      - app
     links:
       - db
       - redis
@@ -35,8 +33,6 @@ services:
   worker:
     extends:
       service: app
-    depends_on:
-      - app
     links:
       - db
       - redis
@@ -45,8 +41,6 @@ services:
   scheduler:
     extends:
       service: app
-    depends_on:
-      - app
     links:
       - db
       - redis
@@ -55,8 +49,6 @@ services:
   monitor:
     extends:
       service: app
-    depends_on:
-      - app
     links:
       - db
       - redis


### PR DESCRIPTION
The depends_on directive is needed if one service depends on another,
it is not needed if one service is simply based on another's definition.

https://docs.docker.com/compose/compose-file/#depends_on