### PR TITLE
Move AWS configs from env vars to constance

### DIFF
--- a/atmo/clusters/provisioners.py
+++ b/atmo/clusters/provisioners.py
@@ -17,7 +17,7 @@ class ClusterProvisioner(Provisioner):
         # the S3 URI to the zeppelin setup step
         self.zeppelin_uri = (
             's3://%s/steps/zeppelin/zeppelin.sh' %
-            self.config['SPARK_EMR_BUCKET']
+            constance.config.AWS_SPARK_EMR_BUCKET
         )
 
     def job_flow_params(self, *args, **kwargs):

--- a/atmo/jobs/provisioners.py
+++ b/atmo/jobs/provisioners.py
@@ -3,6 +3,8 @@
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
 from collections import OrderedDict
 
+import constance
+
 from ..provisioners import Provisioner
 
 
@@ -15,7 +17,7 @@ class SparkJobProvisioner(Provisioner):
     def __init__(self):
         super().__init__()
         # the S3 URI to the job shell script
-        self.batch_uri = 's3://%s/steps/batch.sh' % self.config['SPARK_EMR_BUCKET']
+        self.batch_uri = 's3://%s/steps/batch.sh' % constance.config.AWS_SPARK_EMR_BUCKET
 
     def add(self, identifier, notebook_file):
         """

--- a/atmo/provisioners.py
+++ b/atmo/provisioners.py
@@ -29,11 +29,11 @@ class Provisioner:
         self.config = settings.AWS_CONFIG
         self.spark_emr_configuration_url = (
             'https://s3-%s.amazonaws.com/%s/configuration/configuration.json' %
-            (self.config['AWS_REGION'], self.config['SPARK_EMR_BUCKET'])
+            (self.config['AWS_REGION'], constance.config.AWS_SPARK_EMR_BUCKET)
         )
         # The S3 script URI of the bootstrap script.
         self.script_uri = (
-            's3://%s/bootstrap/telemetry.sh' % self.config['SPARK_EMR_BUCKET']
+            's3://%s/bootstrap/telemetry.sh' % constance.config.AWS_SPARK_EMR_BUCKET
         )
         # A Boto3 EMR client instance.
         self.emr = boto3.client(
@@ -132,7 +132,7 @@ class Provisioner:
                 'Ec2KeyName': self.config['EC2_KEY_NAME'],
                 'KeepJobFlowAliveWhenNoSteps': False,
             },
-            'JobFlowRole': self.config['SPARK_INSTANCE_PROFILE'],
+            'JobFlowRole': constance.config.AWS_SPARK_INSTANCE_PROFILE,
             'ServiceRole': 'EMR_DefaultRole',
             'Applications': [
                 {'Name': 'Spark'},

--- a/atmo/settings.py
+++ b/atmo/settings.py
@@ -173,8 +173,19 @@ class Constance:
             'The spot instance bid price for the cluster workers',
         )),
         ('AWS_EFS_DNS', (
-            'fs-616ca0c8.efs.us-west-2.amazonaws.com',  # the current dev instance of EFS
+            # The default is the current dev instance of EFS.
+            'fs-616ca0c8.efs.us-west-2.amazonaws.com',
             'The DNS name of the EFS mount for EMR clusters'
+        )),
+        ('AWS_SPARK_INSTANCE_PROFILE', (
+            # The default is the current dev instance profile.
+            'telemetry-spark-cloudformation-stage-TelemetrySparkInstanceProfile-UCLC2TTGVX96',
+            'The AWS instance profile to use for the clusters'
+        )),
+        ('AWS_SPARK_EMR_BUCKET', (
+            # The default is the current staging bootstrap bucket.
+            'telemetry-spark-emr-2-stage',
+            'The S3 bucket where the EMR bootstrap scripts are located'
         )),
     ])
 
@@ -191,6 +202,8 @@ class Constance:
             'AWS_USE_SPOT_INSTANCES',
             'AWS_SPOT_BID_CORE',
             'AWS_EFS_DNS',
+            'AWS_SPARK_EMR_BUCKET',
+            'AWS_SPARK_INSTANCE_PROFILE',
         )),
     ])
 
@@ -209,16 +222,6 @@ class AWS:
         'MASTER_INSTANCE_TYPE': 'c3.4xlarge',
         'WORKER_INSTANCE_TYPE': 'c3.4xlarge',
 
-        'SPARK_INSTANCE_PROFILE': values.Value(
-            default='telemetry-spark-cloudformation-'
-                    'TelemetrySparkInstanceProfile-1SATUBVEXG7E3',
-            environ_prefix=None,
-            environ_name='AWS_SPARK_INSTANCE_PROFILE'
-        ),
-        'SPARK_EMR_BUCKET': values.Value(
-            default='telemetry-spark-emr-2',
-            environ_prefix=None,
-            environ_name='AWS_SPARK_EMR_BUCKET'),
         'INSTANCE_APP_TAG': 'telemetry-analysis-worker-instance',
         'EMAIL_SOURCE': 'telemetry-alerts@mozilla.com',
         'MAX_CLUSTER_SIZE': 30,

--- a/tests/clusters/test_provisioners.py
+++ b/tests/clusters/test_provisioners.py
@@ -60,7 +60,7 @@ def test_cluster_start(mocker, cluster_provisioner, ssh_key, user):
             ],
             'KeepJobFlowAliveWhenNoSteps': True,
         },
-        'JobFlowRole': cluster_provisioner.config['SPARK_INSTANCE_PROFILE'],
+        'JobFlowRole': constance.config.AWS_SPARK_INSTANCE_PROFILE,
         'LogUri': (
             's3://log-bucket/%s/%s/2017-02-03T13:48:09+00:00' %
             (cluster_provisioner.log_dir, identifier)

--- a/tests/jobs/test_provisioners.py
+++ b/tests/jobs/test_provisioners.py
@@ -214,7 +214,7 @@ def test_spark_job_run(mocker, is_public, spark_job_provisioner, user):
             ],
             'KeepJobFlowAliveWhenNoSteps': False,
         },
-        'JobFlowRole': spark_job_provisioner.config['SPARK_INSTANCE_PROFILE'],
+        'JobFlowRole': constance.config.AWS_SPARK_INSTANCE_PROFILE,
         'LogUri': (
             's3://log-bucket/%s/%s/2017-02-03T13:48:09+00:00' %
             (spark_job_provisioner.log_dir, identifier)


### PR DESCRIPTION
I saw that jezdez is wanting to move away from env vars, so I'm moving these to constance.