### PR TITLE
save a redirect

### DIFF
--- a/atmo/templates/atmo/base.html
+++ b/atmo/templates/atmo/base.html
@@ -95,7 +95,7 @@
         <div id="footer" class="navbar-collapse collapse">
           <ul class="nav navbar-nav">
             <li><a href="https://wiki.mozilla.org/Telemetry">Docs</a></li>
-            <li><a href="https://wiki.mozilla.org/Telemetry/Custom_analysis_with_spark">Tutorial</a></li>
+            <li><a href="https://docs.telemetry.mozilla.org/tools/spark.html">Tutorial</a></li>
             <li><a href="https://github.com/mozilla/telemetry-analysis-service/issues">Bugs</a></li>
             <li><a href="https://github.com/mozilla/telemetry-analysis-service">Code</a></li>
           </ul>


### PR DESCRIPTION
This replaces the wiki link in the footer with the gitbook link the wiki redirects users towards.