### PR TITLE
Fix #802: Add checking around metrics

### DIFF
--- a/atmo/jobs/models.py
+++ b/atmo/jobs/models.py
@@ -461,8 +461,10 @@ class SparkJobRun(EditedAtModel):
                         }
                     )
 
+                if self.finished_at and self.ready_at:
                     # When job is finished, record time in seconds it took the
-                    # scheduled job to run.
+                    # scheduled job to run. Sometimes `ready_at` won't be
+                    # available if the cluster terminated with errors.
                     run_time = (self.finished_at - self.ready_at).seconds
                     Metric.record(
                         'sparkjob-run-time', run_time,


### PR DESCRIPTION
This code incorrectly assumed that `ready_at` will exist if
`finished_at` exists, which is not true when we have a bootstrap
termination with errors.