### PR TITLE
Extend the OIDC authentication backend with the ability to verify remote user groups against a configured list of allowed user groups.

### DIFF
--- a/atmo/settings.py
+++ b/atmo/settings.py
@@ -369,7 +369,7 @@ class Core(AWS, Celery, Constance, CSP, Configuration):
 
     AUTHENTICATION_BACKENDS = (
         'django.contrib.auth.backends.ModelBackend',
-        'mozilla_django_oidc.auth.OIDCAuthenticationBackend',
+        'atmo.users.backends.AtmoOIDCAuthenticationBackend',
         'guardian.backends.ObjectPermissionBackend',
     )
 
@@ -383,6 +383,11 @@ class Core(AWS, Celery, Constance, CSP, Configuration):
     OIDC_EXEMPT_URLS = [
         'users-login',
     ]
+    # When enabled this will match the remote groups provided via the OIDC
+    # claims with configured list of allowed user groups using UNIX shell-style
+    # wildcards such as * and ?.
+    REMOTE_GROUPS_ENABLED = values.BooleanValue(default=False)
+    REMOTE_GROUPS_ALLOWED = values.SetValue(set(), separator=',')
 
     MESSAGE_TAGS = {
         messages.ERROR: 'danger'

--- a/atmo/users/backends.py
+++ b/atmo/users/backends.py
@@ -1,0 +1,22 @@
+from django.conf import settings
+
+from mozilla_django_oidc.auth import OIDCAuthenticationBackend
+
+
+class AtmoOIDCAuthenticationBackend(OIDCAuthenticationBackend):
+
+    def verify_claims(self, claims):
+        """
+        See if the claims contain a list of user groups (in various forms)
+        and then check it against a configured list of allowed groups.
+        """
+        # shortcut in case remote groups aren't enabled
+        if not settings.REMOTE_GROUPS_ENABLED:
+            return True
+        remote_groups = set(
+            claims.get('groups') or
+            claims.get('https://sso.mozilla.com/claim/groups') or
+            []
+        )
+        allowed_groups = settings.REMOTE_GROUPS_ALLOWED
+        return bool(allowed_groups.intersection(remote_groups))


### PR DESCRIPTION
Disabled by default as it requires deployment changes.

Fix #978.